### PR TITLE
Fix relative path issue with includes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.4.3
+-----
+
+- Fix relative path issue with includes
+
 0.4.2
 -----
 

--- a/sphinx_cmd/__init__.py
+++ b/sphinx_cmd/__init__.py
@@ -1,4 +1,4 @@
 # This file makes sphinx_cmd a Python package
 """Sphinx command-line utilities."""
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/sphinx_cmd/commands/rm.py
+++ b/sphinx_cmd/commands/rm.py
@@ -22,11 +22,15 @@ def find_rst_files(path):
 
 
 def extract_assets(
-    file_path, visited=None, cli_directives=None, context_path=None, verbose=False
+    file_path, visited=None, cli_directives=None, context_path=None, verbose=False, base_dir=None
 ):
     """Extract asset references from an .rst file, recursively parsing includes."""
     if visited is None:
         visited = set()
+
+    # Use the directory of the original file as base for relative path resolution
+    if base_dir is None:
+        base_dir = os.path.dirname(file_path)
 
     # Avoid circular includes
     abs_path = os.path.abspath(file_path)
@@ -52,9 +56,16 @@ def extract_assets(
             for directive, pattern in directive_patterns.items():
                 for match in pattern.findall(content):
                     asset_path = match.strip()
-                    asset_full_path = os.path.normpath(
-                        os.path.join(os.path.dirname(file_path), asset_path)
-                    )
+                    if directive == "include":
+                        # Include paths are resolved relative to the current file
+                        asset_full_path = os.path.normpath(
+                            os.path.join(os.path.dirname(file_path), asset_path)
+                        )
+                    else:
+                        # Non-include assets are resolved relative to the base directory
+                        asset_full_path = os.path.normpath(
+                            os.path.join(base_dir, asset_path)
+                        )
                     asset_abs_path = os.path.abspath(asset_full_path)
 
                     if verbose:
@@ -64,13 +75,14 @@ def extract_assets(
                     if directive == "include":
                         if verbose:
                             print(f"Parsing include: {asset_full_path}")
-                        # Recursively extract assets from included files
+                        # Recursively extract assets from included files, preserving base_dir
                         included_assets = extract_assets(
                             asset_full_path,
-                            visited.copy(),
+                            visited,
                             cli_directives,
                             context_path,
                             verbose,
+                            base_dir,
                         )
                         asset_directives.update(included_assets)
 
@@ -109,11 +121,15 @@ def build_asset_index(rst_files, cli_directives=None, context_path=None, verbose
 
 
 def get_transitive_includes(
-    file_path, visited=None, cli_directives=None, context_path=None, verbose=False
+    file_path, visited=None, cli_directives=None, context_path=None, verbose=False, base_dir=None
 ):
     """Get all files included transitively from a file."""
     if visited is None:
         visited = set()
+
+    # Use the directory of the original file as base for relative path resolution
+    if base_dir is None:
+        base_dir = os.path.dirname(file_path)
 
     # Avoid circular includes
     abs_path = os.path.abspath(file_path)
@@ -148,14 +164,15 @@ def get_transitive_includes(
                     if verbose:
                         print(f"Found include: {include_path}")
 
-                    # Recursively get includes from the included file
+                    # Recursively get includes from the included file, preserving base_dir
                     includes.update(
                         get_transitive_includes(
                             include_full_path,
-                            visited.copy(),
+                            visited,
                             cli_directives,
                             context_path,
                             verbose,
+                            base_dir,
                         )
                     )
     except Exception as e:

--- a/sphinx_cmd/commands/rm.py
+++ b/sphinx_cmd/commands/rm.py
@@ -22,7 +22,12 @@ def find_rst_files(path):
 
 
 def extract_assets(
-    file_path, visited=None, cli_directives=None, context_path=None, verbose=False, base_dir=None
+    file_path,
+    visited=None,
+    cli_directives=None,
+    context_path=None,
+    verbose=False,
+    base_dir=None,
 ):
     """Extract asset references from an .rst file, recursively parsing includes."""
     if visited is None:
@@ -75,7 +80,8 @@ def extract_assets(
                     if directive == "include":
                         if verbose:
                             print(f"Parsing include: {asset_full_path}")
-                        # Recursively extract assets from included files, preserving base_dir
+                        # Recursively extract assets from included files,
+                        # preserving base_dir
                         included_assets = extract_assets(
                             asset_full_path,
                             visited,
@@ -121,7 +127,12 @@ def build_asset_index(rst_files, cli_directives=None, context_path=None, verbose
 
 
 def get_transitive_includes(
-    file_path, visited=None, cli_directives=None, context_path=None, verbose=False, base_dir=None
+    file_path,
+    visited=None,
+    cli_directives=None,
+    context_path=None,
+    verbose=False,
+    base_dir=None,
 ):
     """Get all files included transitively from a file."""
     if visited is None:
@@ -164,7 +175,8 @@ def get_transitive_includes(
                     if verbose:
                         print(f"Found include: {include_path}")
 
-                    # Recursively get includes from the included file, preserving base_dir
+                    # Recursively get includes from the included file,
+                    # preserving base_dir
                     includes.update(
                         get_transitive_includes(
                             include_full_path,


### PR DESCRIPTION
## Summary of changes

- Added a `base_dir` parameter to preserve the original file's directory as the base for relative path resolution
  - When processing non-include directives (like `drawio-figure`), relative paths are now resolved relative to the `base_dir` (the directory of the main file)
